### PR TITLE
bump evaluate to `0.3.0`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ charset-normalizer==2.1.1
 click==8.1.3
 datasets==2.4.0
 dill==0.3.5.1
-evaluate==0.2.2
+evaluate==0.3.0
 filelock==3.8.0
 frozenlist==1.3.1
 fsspec==2022.8.2


### PR DESCRIPTION
There is an issue with `evaluate` before 0.3.0 concerning the Hugging Face hub integration. I suggest upgrading to `0.3.0` which should not have any breaking changes and be functionally equivalent since this version might break in a few months.